### PR TITLE
Fix Surfing Encounter Tables for FireRed

### DIFF
--- a/Resources/PokemonFRLG/EncounterSlotsFR.json
+++ b/Resources/PokemonFRLG/EncounterSlotsFR.json
@@ -5352,1325 +5352,1325 @@
     "surfing": {
         "berry_forest": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "bond_bridge": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "cape_brink": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "poliwhirl",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "celadon_city": [
             {
-                "species": "magikarp",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "magikarp",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "magikarp",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "magikarp",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 30,
+                "maxLevel": 40
             },
             {
-                "species": "grimer",
+                "species": "koffing",
                 "minLevel": 30,
                 "maxLevel": 40
             }
         ],
         "cerulean_cave_1f": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 30,
+                "maxLevel": 40
             },
             {
-                "species": "poliwhirl",
-                "minLevel": 20,
-                "maxLevel": 30
+                "species": "golduck",
+                "minLevel": 40,
+                "maxLevel": 50
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "golduck",
+                "minLevel": 45,
+                "maxLevel": 55
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
+                "minLevel": 40,
+                "maxLevel": 50
             },
             {
                 "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "minLevel": 40,
+                "maxLevel": 50
             }
         ],
         "cerulean_cave_b1f": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "psyduck",
+                "minLevel": 40,
+                "maxLevel": 50
             },
             {
-                "species": "poliwhirl",
-                "minLevel": 20,
-                "maxLevel": 30
+                "species": "golduck",
+                "minLevel": 50,
+                "maxLevel": 60
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "golduck",
+                "minLevel": 55,
+                "maxLevel": 65
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
+                "minLevel": 50,
+                "maxLevel": 60
             },
             {
-                "species": "gyarados",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 50,
+                "maxLevel": 60
             }
         ],
         "cerulean_city": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "cinnabar_island": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "five_island": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 5,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "hoppip",
+                "minLevel": 5,
+                "maxLevel": 15
+            },
+            {
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "five_isle_meadow": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 5,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "hoppip",
+                "minLevel": 5,
+                "maxLevel": 15
+            },
+            {
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "four_island": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
-                "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "wooper",
+                "minLevel": 5,
+                "maxLevel": 15
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
+                "minLevel": 5,
                 "maxLevel": 35
+            },
+            {
+                "species": "wooper",
+                "minLevel": 15,
+                "maxLevel": 25
+            },
+            {
+                "species": "wooper",
+                "minLevel": 15,
+                "maxLevel": 25
+            },
+            {
+                "species": "wooper",
+                "minLevel": 15,
+                "maxLevel": 25
             }
         ],
         "fuchsia_city": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "green_path": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "icefall_cave_back_cavern": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 45
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 45
+            },
+            {
+                "species": "lapras",
+                "minLevel": 30,
+                "maxLevel": 45
             }
         ],
         "icefall_cave_entrance": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
-                "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
+                "species": "seel",
+                "minLevel": 5,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 5,
+                "maxLevel": 35
+            },
+            {
+                "species": "dewgong",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "wooper",
+                "minLevel": 5,
+                "maxLevel": 15
+            },
+            {
+                "species": "wooper",
+                "minLevel": 5,
+                "maxLevel": 15
             }
         ],
         "kindle_road": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "memorial_pillar": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 5,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "hoppip",
+                "minLevel": 5,
+                "maxLevel": 15
+            },
+            {
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "one_island": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "outcast_island": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "pallet_town": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "resort_gorgeous": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "hoppip",
+                "minLevel": 5,
+                "maxLevel": 15
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_10": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_11": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_12": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_13": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_19": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_20": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_21": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_22": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_23": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_24": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_25": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_4": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "route_6": [
             {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "ruin_valley": [
             {
-                "species": "poliwag",
+                "species": "wooper",
+                "minLevel": 5,
+                "maxLevel": 20
+            },
+            {
+                "species": "wooper",
+                "minLevel": 10,
+                "maxLevel": 20
+            },
+            {
+                "species": "wooper",
                 "minLevel": 15,
                 "maxLevel": 25
             },
             {
-                "species": "poliwhirl",
+                "species": "wooper",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
-                "species": "psyduck",
-                "minLevel": 15,
+                "species": "wooper",
+                "minLevel": 20,
                 "maxLevel": 25
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
             }
         ],
         "ss_anne": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 20,
+                "maxLevel": 30
             },
             {
-                "species": "horsea",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "safari_zone_area_1_east": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "dratini",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
+                "maxLevel": 25
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "dragonair",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "safari_zone_area_2_north": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "dratini",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
+                "maxLevel": 25
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "dragonair",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "safari_zone_area_3_west": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "dratini",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
+                "maxLevel": 25
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "dragonair",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "safari_zone_entrance": [
             {
-                "species": "goldeen",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seaking",
+                "species": "psyduck",
                 "minLevel": 20,
-                "maxLevel": 30
-            },
-            {
-                "species": "dratini",
-                "minLevel": 15,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
+                "maxLevel": 25
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
             },
             {
-                "species": "dragonair",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "seafoam_islands_b3f": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "seel",
+                "minLevel": 25,
+                "maxLevel": 35
             },
             {
                 "species": "horsea",
-                "minLevel": 20,
+                "minLevel": 25,
                 "maxLevel": 30
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "dewgong",
+                "minLevel": 35,
+                "maxLevel": 40
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
+                "minLevel": 30,
+                "maxLevel": 40
             },
             {
-                "species": "gyarados",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "seafoam_islands_b4f": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "seel",
+                "minLevel": 25,
+                "maxLevel": 35
             },
             {
                 "species": "horsea",
-                "minLevel": 20,
+                "minLevel": 25,
                 "maxLevel": 30
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "dewgong",
+                "minLevel": 35,
+                "maxLevel": 40
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
-                "maxLevel": 25
+                "minLevel": 30,
+                "maxLevel": 40
             },
             {
-                "species": "gyarados",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "golduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "tanoby_ruins": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "trainer_tower": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "treasure_beach": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "vermilion_city": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 10
             },
             {
-                "species": "shellder",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 10,
+                "maxLevel": 20
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "horsea",
-                "minLevel": 25,
-                "maxLevel": 35
-            },
-            {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
-            }
-        ],
-        "viridian_city": [
-            {
-                "species": "poliwag",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "poliwhirl",
+                "species": "tentacool",
                 "minLevel": 20,
                 "maxLevel": 30
             },
             {
-                "species": "gyarados",
-                "minLevel": 15,
+                "species": "tentacool",
+                "minLevel": 30,
+                "maxLevel": 35
+            },
+            {
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            }
+        ],
+        "viridian_city": [
+            {
+                "species": "psyduck",
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
-                "minLevel": 15,
+                "minLevel": 20,
                 "maxLevel": 25
             },
             {
                 "species": "psyduck",
                 "minLevel": 25,
+                "maxLevel": 30
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 30,
                 "maxLevel": 35
+            },
+            {
+                "species": "psyduck",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "water_labyrinth": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 5,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "hoppip",
+                "minLevel": 5,
+                "maxLevel": 15
+            },
+            {
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ],
         "water_path": [
             {
-                "species": "horsea",
-                "minLevel": 15,
-                "maxLevel": 25
+                "species": "tentacool",
+                "minLevel": 5,
+                "maxLevel": 20
             },
             {
-                "species": "qwilfish",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "gyarados",
-                "minLevel": 15,
-                "maxLevel": 25
-            },
-            {
-                "species": "seadra",
-                "minLevel": 25,
+                "species": "tentacool",
+                "minLevel": 20,
                 "maxLevel": 35
             },
             {
-                "species": "psyduck",
-                "minLevel": 25,
-                "maxLevel": 35
+                "species": "tentacool",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
+            },
+            {
+                "species": "tentacruel",
+                "minLevel": 35,
+                "maxLevel": 40
             }
         ]
     },

--- a/Resources/PokemonFRLG/EncounterSlotsLG.json
+++ b/Resources/PokemonFRLG/EncounterSlotsLG.json
@@ -3906,7 +3906,7 @@
                 "maxLevel": 23
             }
         ],
-        "safari_zone_area_1_-_east": [
+        "safari_zone_area_1_east": [
             {
                 "species": "nidoran♀",
                 "minLevel": 24,
@@ -3968,7 +3968,7 @@
                 "maxLevel": 28
             }
         ],
-        "safari_zone_area_2_-_north": [
+        "safari_zone_area_2_north": [
             {
                 "species": "rhyhorn",
                 "minLevel": 26,
@@ -4030,7 +4030,7 @@
                 "maxLevel": 28
             }
         ],
-        "safari_zone_area_3_-_west": [
+        "safari_zone_area_3_west": [
             {
                 "species": "doduo",
                 "minLevel": 26,
@@ -6349,7 +6349,7 @@
                 "maxLevel": 40
             }
         ],
-        "safari_zone_area_1_-_east": [
+        "safari_zone_area_1_east": [
             {
                 "species": "slowpoke",
                 "minLevel": 20,
@@ -6376,7 +6376,7 @@
                 "maxLevel": 40
             }
         ],
-        "safari_zone_area_2_-_north": [
+        "safari_zone_area_2_north": [
             {
                 "species": "slowpoke",
                 "minLevel": 20,
@@ -6403,7 +6403,7 @@
                 "maxLevel": 40
             }
         ],
-        "safari_zone_area_3_-_west": [
+        "safari_zone_area_3_west": [
             {
                 "species": "slowpoke",
                 "minLevel": 20,
@@ -7107,7 +7107,7 @@
                 "maxLevel": 5
             }
         ],
-        "safari_zone_area_1_-_east": [
+        "safari_zone_area_1_east": [
             {
                 "species": "magikarp",
                 "minLevel": 5,
@@ -7119,7 +7119,7 @@
                 "maxLevel": 5
             }
         ],
-        "safari_zone_area_2_-_north": [
+        "safari_zone_area_2_north": [
             {
                 "species": "magikarp",
                 "minLevel": 5,
@@ -7131,7 +7131,7 @@
                 "maxLevel": 5
             }
         ],
-        "safari_zone_area_3_-_west": [
+        "safari_zone_area_3_west": [
             {
                 "species": "magikarp",
                 "minLevel": 5,
@@ -7894,7 +7894,7 @@
                 "maxLevel": 15
             }
         ],
-        "safari_zone_area_1__-__east": [
+        "safari_zone_area_1_east": [
             {
                 "species": "goldeen",
                 "minLevel": 5,
@@ -7911,7 +7911,7 @@
                 "maxLevel": 15
             }
         ],
-        "safari_zone_area_2__-__north": [
+        "safari_zone_area_2_north": [
             {
                 "species": "goldeen",
                 "minLevel": 5,
@@ -7928,7 +7928,7 @@
                 "maxLevel": 15
             }
         ],
-        "safari_zone_area_3__-__west": [
+        "safari_zone_area_3_west": [
             {
                 "species": "goldeen",
                 "minLevel": 5,
@@ -9099,7 +9099,7 @@
                 "maxLevel": 35
             }
         ],
-        "safari_zone_area_1__-__east": [
+        "safari_zone_area_1_east": [
             {
                 "species": "goldeen",
                 "minLevel": 15,
@@ -9126,7 +9126,7 @@
                 "maxLevel": 35
             }
         ],
-        "safari_zone_area_2__-__north": [
+        "safari_zone_area_2_north": [
             {
                 "species": "goldeen",
                 "minLevel": 15,
@@ -9153,7 +9153,7 @@
                 "maxLevel": 35
             }
         ],
-        "safari_zone_area_3__-__west": [
+        "safari_zone_area_3_west": [
             {
                 "species": "goldeen",
                 "minLevel": 15,


### PR DESCRIPTION
The original version mistakenly duplicated the Super Rod encounters.

Also fixes some slug names for the Safari Zone