### PR TITLE
Fix Nidoran slugs in FRLG encounter tables

### DIFF
--- a/Resources/PokemonFRLG/EncounterSlotsFR.json
+++ b/Resources/PokemonFRLG/EncounterSlotsFR.json
@@ -3370,7 +3370,7 @@
                 "maxLevel": 7
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 6,
                 "maxLevel": 6
             },
@@ -3390,7 +3390,7 @@
                 "maxLevel": 3
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 7,
                 "maxLevel": 7
             },
@@ -3400,7 +3400,7 @@
                 "maxLevel": 5
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 6,
                 "maxLevel": 6
             },
@@ -3846,7 +3846,7 @@
         ],
         "safari_zone_area_1_east": [
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 24,
                 "maxLevel": 24
             },
@@ -3876,7 +3876,7 @@
                 "maxLevel": 33
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 24,
                 "maxLevel": 24
             },
@@ -3913,7 +3913,7 @@
                 "maxLevel": 26
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 30,
                 "maxLevel": 30
             },
@@ -3975,7 +3975,7 @@
                 "maxLevel": 26
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 22,
                 "maxLevel": 22
             },
@@ -4000,7 +4000,7 @@
                 "maxLevel": 30
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 30,
                 "maxLevel": 30
             },
@@ -4037,7 +4037,7 @@
                 "maxLevel": 25
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 22,
                 "maxLevel": 22
             },

--- a/Resources/PokemonFRLG/EncounterSlotsLG.json
+++ b/Resources/PokemonFRLG/EncounterSlotsLG.json
@@ -2502,7 +2502,7 @@
                 "maxLevel": 7
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 6,
                 "maxLevel": 6
             },
@@ -2522,7 +2522,7 @@
                 "maxLevel": 3
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 7,
                 "maxLevel": 7
             },
@@ -2532,7 +2532,7 @@
                 "maxLevel": 5
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 6,
                 "maxLevel": 6
             },
@@ -3851,7 +3851,7 @@
                 "maxLevel": 25
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 22,
                 "maxLevel": 22
             },
@@ -3908,7 +3908,7 @@
         ],
         "safari_zone_area_1_east": [
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 24,
                 "maxLevel": 24
             },
@@ -3938,7 +3938,7 @@
                 "maxLevel": 33
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 24,
                 "maxLevel": 24
             },
@@ -3975,7 +3975,7 @@
                 "maxLevel": 26
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 30,
                 "maxLevel": 30
             },
@@ -4037,7 +4037,7 @@
                 "maxLevel": 26
             },
             {
-                "species": "nidoran♀",
+                "species": "nidoran-f",
                 "minLevel": 22,
                 "maxLevel": 22
             },
@@ -4062,7 +4062,7 @@
                 "maxLevel": 30
             },
             {
-                "species": "nidoran♂",
+                "species": "nidoran-m",
                 "minLevel": 30,
                 "maxLevel": 30
             },


### PR DESCRIPTION
Swaps out the gender symbols for the appropriate `-m` and `-f` suffixes